### PR TITLE
Add controller support

### DIFF
--- a/Source/HypertubeDirectionProtocol/Private/HypertubeDirectionProtocol.cpp
+++ b/Source/HypertubeDirectionProtocol/Private/HypertubeDirectionProtocol.cpp
@@ -50,12 +50,18 @@ public:
 				bool bDownA = PC->IsInputKeyDown(EKeys::A);
 				bool bDownD = PC->IsInputKeyDown(EKeys::D);
 
+				bool bLeftStickLeft = PC->IsInputKeyDown(EKeys::Gamepad_LeftStick_Left);
+				bool bLeftStickRight = PC->IsInputKeyDown(EKeys::Gamepad_LeftStick_Right);
+
+				bool bLeft = (bDownA || bLeftStickLeft);
+				bool bRight = (bDownD || bLeftStickRight);
+
 				int32 Index = INDEX_NONE;
-				if (bDownA && !bDownD)
+				if (bLeft && !bRight)
 				{
 					Index = 0;
 				}
-				else if (bDownD && !bDownA)
+				else if (bRight && !bLeft)
 				{
 					Index = Outputs.Num() - 1;
 				}


### PR DESCRIPTION
Very simple change to add controller support, since keyboard presses are not detecting when using a controller. Uses the left stick's left/right to mimic the A/D selection.

Tested on version 1.1.2.1.